### PR TITLE
PHP 5.6下，cURL问题

### DIFF
--- a/application/controllers/user.php
+++ b/application/controllers/user.php
@@ -163,10 +163,12 @@ class User extends TT_Controller {
 	public function _upload($filename)
 	{
 		$ch = curl_init();
-		$data = array('filename'=>'@'.$filename);
+		$cfile = new CurlFile($filename);
+		$data = array('filename'=> $cfile);
 		curl_setopt($ch,CURLOPT_URL,$this->config->config['msfs_url']);
 		curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
 		curl_setopt($ch,CURLOPT_POST,true);
+		curl_setopt($ch, CURLOPT_SAFE_UPLOAD, false);
 		curl_setopt($ch,CURLOPT_POSTFIELDS,$data);
 		$result = curl_exec($ch);
 		curl_close($ch);


### PR DESCRIPTION
在TTAutoDeploy下面，PHP的版本是5.6，cURL与之前的版本有变动。在5.6下面，会导致curl到msfs后，msfs获取不到filename。